### PR TITLE
Fix unwrap panic in bazel-lsp for Label

### DIFF
--- a/starlark/src/docs/markdown.rs
+++ b/starlark/src/docs/markdown.rs
@@ -136,7 +136,7 @@ fn render_function_parameters(params: &[DocParam]) -> Option<String> {
             let docs = render_doc_string(DSOpts::Combined, docs).unwrap_or_default();
 
             let mut lines_iter = docs.lines();
-            let first_line = lines_iter.next().unwrap();
+            let first_line = lines_iter.next().unwrap_or_default();
             let rest_of_lines: Vec<&str> = lines_iter.collect();
 
             let _ = writeln!(output, "* `{name}`: {first_line}");


### PR DESCRIPTION
Fix for https://github.com/cameron-martin/bazel-lsp/issues/41 - Panic when rendering Label documentation

Looks like documentation may contain no lines (in case of bazel-lsp at least), and this quick fix makes it work. Not sure whether it's the best solution, or the assumption that docs should contain non-empty text should be enforced somewhere, but it is not at this point so making it not panic seems like good solution.