### PR TITLE
Bump rustyline dep to 14.0.0

### DIFF
--- a/starlark/Cargo.toml
+++ b/starlark/Cargo.toml
@@ -50,7 +50,7 @@ allocative = { workspace = true, features = ["bumpalo", "num-bigint"] }
 cmp_any = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rustyline = "11.0"
+rustyline = "14.0"
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["small_rng"] }


### PR DESCRIPTION
This allows one to have `nix` 0.28 instead of 0.26 in one's dep graph, so that platform support of `rustyline` becomes better. No behavioral change intended for starlark-rust because the dependence on rustyline is minimal.

Note though that nix's MSRV is raised to 1.65 starting from 0.27.0, and so does starlark-rust.