### PR TITLE
Fix data race in PinnedPagableArc type

### DIFF
--- a/pagable/src/pagable_arc.rs
+++ b/pagable/src/pagable_arc.rs
@@ -810,7 +810,7 @@ impl<T: Pagable> PagableArcInner<T> {
                 data.pin(value);
             }
 
-            self.pinned_count.fetch_add(1, Ordering::Relaxed);
+            self.pinned_count.fetch_add(1, Ordering::Release);
 
             Ok(())
         }
@@ -836,7 +836,7 @@ impl<T: Pagable> PagableArcInner<T> {
     fn try_alloc_pinned(&self) -> bool {
         if self
             .pinned_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            .fetch_update(Ordering::Acquire, Ordering::Relaxed, |v| {
                 if v == 0 { None } else { Some(v + 1) }
             })
             .is_ok()
@@ -848,7 +848,7 @@ impl<T: Pagable> PagableArcInner<T> {
             let _lock = self.lock.lock();
             let data = unsafe { &mut *self.data.get() };
             if data.try_pin() {
-                self.pinned_count.fetch_add(1, Ordering::Relaxed);
+                self.pinned_count.fetch_add(1, Ordering::Release);
                 return true;
             }
         }
@@ -871,7 +871,8 @@ impl<T: Pagable> PagableArcInner<T> {
     /// - Thread B: try_alloc_pinned slow path, acquires lock, increments count to 1
     /// - Thread A: acquires lock, but count is now 1, so we must NOT transition
     fn release_pin(ptr: &triomphe::Arc<Self>) {
-        if ptr.pinned_count.fetch_sub(1, Ordering::Relaxed) == 1 {
+        if ptr.pinned_count.fetch_sub(1, Ordering::Release) == 1 {
+            std::sync::atomic::fence(Ordering::Acquire);
             let _lock = ptr.lock.lock();
             if ptr.pinned_count.load(Ordering::Relaxed) == 0 {
                 let data: &mut _ = unsafe { &mut *ptr.data.get() };


### PR DESCRIPTION
When `PinnedPagableArc` is dropped the pin counter is decremented with a `Relaxed` ordering. This can result in a data race when two threads drop an owned instance of a type duplicated via `Clone`.

## Reproduction:

### Test Case:
```rust
#[test]
fn racy_test() {
    let backend = InMemoryPagableStorage::new();
    let foo = PinnedPagableArc::new(false, PagableStorageHandle::new(backend.handle()));
    let bar = foo.clone();
    std::thread::scope(|s| {
        s.spawn(move || drop(bar));
        let _read = *foo;
        drop(foo);
    });
}
```

### Running with Miri:
`MIRIFLAGS="-Zmiri-many-seeds=0..16" cargo +nightly miri test -p pagable --test repro`

### Miri output:
```
error: Undefined Behavior: Data race detected between (1) non-atomic read on thread `racy_test`
and (2) retag write of type `pagable::pagable_arc::PagableArcInnerData<bool>` on thread `unnamed-3`
at alloc768762+0x20
   --> pagable/src/pagable_arc.rs:877:44
    |
877 |                 let data: &mut _ = unsafe { &mut *ptr.data.get() };
    |                                             ^^^^^^^^^^^^^^^^^^^^ (2) just happened here
help: and (1) occurred earlier here
   --> pagable/src/pagable_arc.rs:716:14
```

## Fix:

Synchronise the `PinnedPagableArc` pin counter with `Release`/`Acquire` memory orderings and use a fence before data is unpinned. 

This mirrors the synchronisation used by [`std::sync::Arc`](https://doc.rust-lang.org/src/alloc/sync.rs.html#2827). 
If you'd like to see another example [I found a similar bug in the `stabby` crate](https://github.com/ZettaScaleLabs/stabby/pull/139)
