### PR TITLE
cargo: Consume buck2 crates via git in the starlark-rust repo (#236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    # Cargo checks out facebook/buck2 (a git dependency) with libgit2, which
+    # rejects that repository's deepest paths on Windows unless told otherwise.
+    - if: runner.os == 'Windows'
+      run: git config --global core.longpaths true
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.toolchain }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,14 @@ Starlark is currently developed in Meta's internal repositories and then
 exported out to GitHub by a Meta team member; however, we invite you to
 submit pull requests as described below.
 
+## Building
+
+The workspace depends on crates from
+[facebook/buck2](https://github.com/facebook/buck2) through git, so the first
+build fetches that repository. Its tree contains paths longer than Windows
+allows by default; on Windows run `git config --global core.longpaths true`
+before building.
+
 ## Pull Requests
 
 We actively welcome your pull requests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
+# Workspace root of https://github.com/facebook/starlark-rust. ShipIt moves this
+# file to the top of that repository; inside fbsource and facebook/buck2 the
+# starlark crates are members of the buck2 workspace instead and this file is
+# unused.
+#
+# Crates maintained in facebook/buck2 are consumed from that repository's main
+# branch so that a change to one of them and to starlark can land together. The
+# versions are the ones that `cargo publish` uses.
+
 [workspace]
 members = [
-    "allocative/allocative",
-    "allocative/allocative_derive",
-    "gazebo/gazebo",
-    "gazebo/display_container",
-    "gazebo/dupe",
-    "gazebo/strong_hash",
-    "gazebo/strong_hash_derive",
-    "pagable",
-    "pagable_derive",
     "starlark",
     "starlark_bin",
     "starlark_derive",
@@ -24,54 +24,18 @@ license = "Apache-2.0"
 repository = "https://github.com/facebook/starlark-rust"
 
 [workspace.dependencies]
-allocative = { version = "0.3.6", path = "allocative/allocative" }
-cmp_any = { version = "0.8.1", path = "gazebo/cmp_any" }
-display_container = { version = "0.9.0", path = "gazebo/display_container" }
-dupe = { version = "0.9.1", path = "gazebo/dupe" }
-gazebo = { path = "gazebo/gazebo" }
-strong_hash = { version = "0.1.0", path = "gazebo/strong_hash" }
+allocative = { version = "0.3.6", git = "https://github.com/facebook/buck2.git", branch = "main", features = ["bumpalo", "dashmap", "hashbrown", "num-bigint", "triomphe"] }
+cmp_any = { version = "0.8.1", git = "https://github.com/facebook/buck2.git", branch = "main" }
+display_container = { version = "0.9.0", git = "https://github.com/facebook/buck2.git", branch = "main" }
+dupe = { version = "0.9.1", git = "https://github.com/facebook/buck2.git", branch = "main" }
+pagable = { version = "0.4.2", git = "https://github.com/facebook/buck2.git", branch = "main" }
+strong_hash = { version = "0.1.0", git = "https://github.com/facebook/buck2.git", branch = "main" }
 
-starlark_lsp = { version = "0.14", path = "starlark_lsp" }
-starlark_map = { version = "0.14", path = "starlark_map" }
-starlark_syntax = { version = "0.14", path = "starlark_syntax" }
-
-anyhow = "1.0.102"
-ctor = "1.0.5"
+anyhow = "1.0.104"
+blake3 = { version = "1.8", features = ["mmap", "rayon", "traits-preview"] }
 derivative = "2.2"
 derive_more = { version = "2.1.1", features = ["full"] }
-either = "1.8"
 equivalent = "1.0.2"
-erased-serde = "0.4.10"
-fancy-regex = "0.19.0"
-indenter = "0.3.4"
-inventory = "0.3.24"
-memchr = "2.8.0"
-num-bigint = { version = "0.5.1", features = ["serde"] }
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-ref-cast = "1.0.18"
-relative-path = { version = "2.0.1", features = ["serde"] }
-syn = { version = "3", features = ["full"] }
-
-pagable = { version = "0.4.2", path = "pagable" }
-# dependencies of pagable
-async-trait = "0.1.86"
-blake3 = { version = "1.8", features = ["default", "rayon", "std", "traits-preview"] }
-bytemuck = { version = "1.25", features = ["const_zeroed", "derive", "min_const_generics", "must_cast", "nightly_stdsimd"] }
-dashmap = "6.1.0"
-indexmap = { version = "2.14.0", features = ["serde"] }
-once_cell = "1.21.4"
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
-postcard = { version = "1.0.8", features = ["use-crc", "use-std"] }
-regex = "1.12.3"
-sequence_trie = "0.3.6"
-serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["raw_value"] }
-smallvec = { version = "1.15", features = ["const_generics"] }
-sorted_vector_map = "0.2.1"
-static_assertions = "1.1.0"
-static_interner = "0.1.2"
-take_mut = "0.2"
-thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
-triomphe = "0.1.11"
+memchr = "2.8.3"
+num-bigint = { version = "0.5.1", features = ["rand_0_10", "serde"] }
+triomphe = { version = "0.1.16", features = ["arc-swap"] }


### PR DESCRIPTION
Summary:

This is option C from https://fb.workplace.com/groups/starlark/permalink/1968828847139267/.

Today ShipIt copies `allocative`, `gazebo`, `pagable` and `pagable_derive`
into facebook/starlark-rust and the handwritten workspace root there lists
them as members. That layout is what blocked D108568489 and D108568490
(allocative and gazebo in autocargo): once autocargo generates those crates'
manifests with workspace inheritance, the starlark-rust root would have to
mirror every dependency of every copied crate.

Instead, the starlark-rust workspace now depends on those crates as git
dependencies on facebook/buck2's main branch. Simultaneous changes to, say,
pagable and starlark still land as one fbsource commit; the starlark-rust
repo picks them up once both ShipIt syncs have run. The `version` on each git
dependency is what `cargo publish` falls back to, so publishing starlark from
that repo keeps working (dependencies must be published first, as before).

The pagable third-party pins and the gazebo/starlark_* workspace entries that
only existed for the copied crates are gone; the remaining third-party entries
are the ones the crate manifests reference through `workspace = true`, at the
versions the buck2 workspace uses.

The matching ShipIt change (stop copying the directories) must land after
this: the old root refers to the copied members, the new one ignores them.

Reviewed By: dtolnay

Differential Revision: D119131392


